### PR TITLE
adding Connection Attributes (#2)

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   attach-artifact-to-release:
-    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@v0.4.1
+    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@main
     secrets: inherit

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   create-release:
-    uses: liquibase/build-logic/.github/workflows/create-release.yml@v0.4.1
+    uses: liquibase/build-logic/.github/workflows/create-release.yml@main
     secrets: inherit

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   release:
-    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@v0.4.1
+    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@main
     secrets: inherit

--- a/src/main/java/liquibase/ext/singlestore/SingleStoreConnection.java
+++ b/src/main/java/liquibase/ext/singlestore/SingleStoreConnection.java
@@ -1,0 +1,113 @@
+package liquibase.ext.singlestore;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.util.Properties;
+import java.util.ResourceBundle;
+import liquibase.Scope;
+import liquibase.configuration.LiquibaseConfiguration;
+import liquibase.database.DatabaseConnection;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.exception.DatabaseException;
+
+public class SingleStoreConnection extends JdbcConnection {
+    private final DatabaseConnection originalConnection;
+
+    public SingleStoreConnection() {
+        super();
+        this.originalConnection = null;
+    }
+
+    public SingleStoreConnection(Connection connection) {
+        super(connection);
+        this.originalConnection = null;
+    }
+
+    /**
+     * Constructor for creating a replacement connection that wraps an original connection.
+     * When this connection is closed, the original connection will also be closed.
+     */
+    SingleStoreConnection(Connection connection, DatabaseConnection originalConnection) {
+        super(connection);
+        this.originalConnection = originalConnection;
+    }
+
+    @Override
+    public int getPriority() {
+        // Use maximum priority so this connection class is used for SingleStore
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public void close() throws DatabaseException {
+        // Also close the original connection that this connection replaced.
+        // This handles the case where a user manually creates a connection and passes it to
+        // Liquibase. We create a replacement connection with connectionAttributes, but need
+        // to ensure the original connection is also cleaned up.
+        if (originalConnection != null && !originalConnection.isClosed()) {
+            originalConnection.close();
+        }
+        super.close();
+    }
+
+    @Override
+    public void open(String url, Driver driverObject, Properties driverProperties)
+            throws DatabaseException {
+        // This method is called by Liquibase when a new connection is needed, BEFORE the
+        // connection is actually established. We append connectionAttributes to the URL
+        // so SingleStore can track that this connection is from Liquibase.
+        if (url != null && url.startsWith("jdbc:singlestore") && !url.contains("connectionAttributes=")) {
+            url = addConnectionAttributesToUrl(url);
+            
+            String liquibaseVersion = getLiquibaseVersion();
+            Scope.getCurrentScope().getLog(getClass()).info(
+                "Connecting to SingleStore with attributes: _connector_name=Liquibase, _connector_version=" + liquibaseVersion);
+        }
+        
+        // Let parent class handle the actual connection creation with our modified url
+        super.open(url, driverObject, driverProperties);
+    }
+
+    /**
+     * Adds Liquibase connection attributes to a SingleStore JDBC URL.
+     * This is a static method so it can be called from SingleStoreDatabase.setConnection()
+     * for manually-created connections.
+     */
+    static String addConnectionAttributesToUrl(String url) {
+        String liquibaseVersion = getLiquibaseVersion();
+        String connectionAttributes = "_connector_name:Liquibase,_connector_version:" + liquibaseVersion;
+        
+        String separator = url.contains("?") ? "&" : "?";
+        
+        if (url.contains("connectionAttributes=")) {
+            // Append to existing connectionAttributes
+            return url.replaceFirst(
+                "(connectionAttributes=[^&]*)",
+                "$1," + connectionAttributes
+            );
+        } else {
+            // Add new connectionAttributes parameter
+            return url + separator + "connectionAttributes=" + connectionAttributes;
+        }
+    }
+
+    private static String getLiquibaseVersion() {
+        try {
+            // Try to get version from Liquibase core's build info
+            String version = liquibase.util.LiquibaseUtil.getBuildVersion();
+            if (version != null && !version.isEmpty() && !version.equals("DEV")) {
+                return version;
+            }
+        } catch (Exception e) {
+            // Ignore and try alternative methods
+        }
+        
+        try {
+            // Fallback: Read from liquibase core's build properties
+            ResourceBundle coreBundle = ResourceBundle.getBundle("liquibase/build");
+            return coreBundle.getString("build.version");
+        } catch (Exception e) {
+            return "unknown";
+        }
+    }
+}

--- a/src/main/java/liquibase/ext/singlestore/SingleStoreConnection.java
+++ b/src/main/java/liquibase/ext/singlestore/SingleStoreConnection.java
@@ -5,7 +5,6 @@ import java.sql.Driver;
 import java.util.Properties;
 import java.util.ResourceBundle;
 import liquibase.Scope;
-import liquibase.configuration.LiquibaseConfiguration;
 import liquibase.database.DatabaseConnection;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
@@ -39,6 +38,11 @@ public class SingleStoreConnection extends JdbcConnection {
     }
 
     @Override
+    public boolean supports(String url) {
+        return url != null && url.startsWith("jdbc:singlestore");
+    }
+
+    @Override
     public void close() throws DatabaseException {
         // Also close the original connection that this connection replaced.
         // This handles the case where a user manually creates a connection and passes it to
@@ -56,16 +60,25 @@ public class SingleStoreConnection extends JdbcConnection {
         // This method is called by Liquibase when a new connection is needed, BEFORE the
         // connection is actually established. We append connectionAttributes to the URL
         // so SingleStore can track that this connection is from Liquibase.
-        if (url != null && url.startsWith("jdbc:singlestore") && !url.contains("connectionAttributes=")) {
-            url = addConnectionAttributesToUrl(url);
-            
-            String liquibaseVersion = getLiquibaseVersion();
-            Scope.getCurrentScope().getLog(getClass()).info(
-                "Connecting to SingleStore with attributes: _connector_name=Liquibase, _connector_version=" + liquibaseVersion);
+        if (url != null && url.startsWith("jdbc:singlestore")) {
+            String urlWithAttributes = addConnectionAttributesToUrl(url);
+            if (!urlWithAttributes.equals(url)) {
+                String liquibaseVersion = getLiquibaseVersion();
+                Scope.getCurrentScope().getLog(getClass()).info(
+                    "Connecting to SingleStore with attributes: _connector_name=Liquibase, _connector_version=" + liquibaseVersion);
+            }
+            url = urlWithAttributes;
         }
         
         // Let parent class handle the actual connection creation with our modified url
         super.open(url, driverObject, driverProperties);
+    }
+
+    /**
+     * Returns true if the URL already includes Liquibase SingleStore connector attributes.
+     */
+    static boolean hasLiquibaseConnectionAttributes(String url) {
+        return url != null && url.contains("_connector_name:Liquibase");
     }
 
     /**
@@ -74,6 +87,9 @@ public class SingleStoreConnection extends JdbcConnection {
      * for manually-created connections.
      */
     static String addConnectionAttributesToUrl(String url) {
+        if (hasLiquibaseConnectionAttributes(url)) {
+            return url;
+        }
         String liquibaseVersion = getLiquibaseVersion();
         String connectionAttributes = "_connector_name:Liquibase,_connector_version:" + liquibaseVersion;
         

--- a/src/main/java/liquibase/ext/singlestore/SingleStoreDatabase.java
+++ b/src/main/java/liquibase/ext/singlestore/SingleStoreDatabase.java
@@ -1,9 +1,11 @@
 package liquibase.ext.singlestore;
 
+import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
+import liquibase.Scope;
 import liquibase.database.DatabaseConnection;
 import liquibase.database.core.MariaDBDatabase;
 import liquibase.database.jvm.JdbcConnection;
@@ -56,6 +58,45 @@ public class SingleStoreDatabase extends MariaDBDatabase {
             return "com.singlestore.jdbc.Driver";
         }
         return super.getDefaultDriver(url);
+    }
+
+    @Override
+    public void setConnection(final DatabaseConnection conn) {
+        DatabaseConnection connectionToUse = conn;
+        
+        // If a user creates a JDBC connection manually and passes it to Liquibase,
+        // this method will be called. Normally, a connection will be opened by
+        // Liquibase based on the connection URL configured. In that case, the
+        // SingleStoreConnection class will ensure connectionAttributes are set.
+        // However, when a user creates the connection programmatically and passes it to
+        // Liquibase, we need to check if connectionAttributes are missing and create
+        // a replacement connection with them.
+        if (!(conn instanceof SingleStoreConnection)
+            && conn instanceof JdbcConnection) {
+            JdbcConnection jdbcConn = (JdbcConnection) conn;
+            String url = jdbcConn.getURL();
+            
+            // Check if it's a SingleStore connection without connectionAttributes
+            if (url != null && url.startsWith("jdbc:singlestore") && !url.contains("connectionAttributes=")) {
+                // Create a replacement connection with connectionAttributes
+                try {
+                    String modifiedUrl = SingleStoreConnection.addConnectionAttributesToUrl(url);
+                    connectionToUse = new SingleStoreConnection(
+                        DriverManager.getConnection(modifiedUrl),
+                        conn  // Pass original connection so it gets closed when replacement is closed
+                    );
+                    
+                    Scope.getCurrentScope().getLog(getClass()).info(
+                        "Replaced manually-created connection with one that includes SingleStore connection attributes");
+                } catch (SQLException e) {
+                    // If we can't create a replacement connection, use the original
+                    Scope.getCurrentScope().getLog(getClass()).fine(
+                        "Could not add connection attributes to manually-created connection: " + e.getMessage());
+                }
+            }
+        }
+        
+        super.setConnection(connectionToUse);
     }
 
     @Override

--- a/src/main/java/liquibase/ext/singlestore/SingleStoreDatabase.java
+++ b/src/main/java/liquibase/ext/singlestore/SingleStoreDatabase.java
@@ -1,10 +1,12 @@
 package liquibase.ext.singlestore;
 
+import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.Properties;
 import liquibase.Scope;
 import liquibase.database.DatabaseConnection;
 import liquibase.database.core.MariaDBDatabase;
@@ -75,14 +77,25 @@ public class SingleStoreDatabase extends MariaDBDatabase {
             && conn instanceof JdbcConnection) {
             JdbcConnection jdbcConn = (JdbcConnection) conn;
             String url = jdbcConn.getURL();
-            
-            // Check if it's a SingleStore connection without connectionAttributes
-            if (url != null && url.startsWith("jdbc:singlestore") && !url.contains("connectionAttributes=")) {
-                // Create a replacement connection with connectionAttributes
+
+            // Prefer JDBC metadata URL (may include more than Liquibase's stripped getURL()).
+            String baseUrl;
+            try {
+                baseUrl = jdbcConn.getWrappedConnection().getMetaData().getURL();
+            } catch (SQLException e) {
+                baseUrl = url;
+            }
+            if (baseUrl == null) {
+                baseUrl = url;
+            }
+
+            if (url != null && url.startsWith("jdbc:singlestore")
+                && !SingleStoreConnection.hasLiquibaseConnectionAttributes(url)) {
                 try {
-                    String modifiedUrl = SingleStoreConnection.addConnectionAttributesToUrl(url);
+                    String modifiedUrl = SingleStoreConnection.addConnectionAttributesToUrl(baseUrl);
+                    Connection replacement = openReplacementSingleStoreJdbcConnection(modifiedUrl, jdbcConn);
                     connectionToUse = new SingleStoreConnection(
-                        DriverManager.getConnection(modifiedUrl),
+                        replacement,
                         conn  // Pass original connection so it gets closed when replacement is closed
                     );
                     
@@ -97,6 +110,27 @@ public class SingleStoreDatabase extends MariaDBDatabase {
         }
         
         super.setConnection(connectionToUse);
+    }
+
+    /**
+     * Opens a JDBC connection using a modified URL, then retries with {@code user} in {@link Properties}
+     * when the URL-only attempt fails (e.g. credentials supplied only via properties on the original
+     * connection). Passwords that are not represented in the URL and not recoverable from the API may
+     * still require keeping the original connection.
+     */
+    private static Connection openReplacementSingleStoreJdbcConnection(String jdbcUrl, JdbcConnection jdbcConn)
+            throws SQLException {
+        try {
+            return DriverManager.getConnection(jdbcUrl);
+        } catch (SQLException urlOnlyFailure) {
+            String user = jdbcConn.getConnectionUserName();
+            if (user == null || user.isEmpty()) {
+                throw urlOnlyFailure;
+            }
+            Properties info = new Properties();
+            info.setProperty("user", user);
+            return DriverManager.getConnection(jdbcUrl, info);
+        }
     }
 
     @Override

--- a/src/main/resources/META-INF/services/liquibase.database.DatabaseConnection
+++ b/src/main/resources/META-INF/services/liquibase.database.DatabaseConnection
@@ -1,0 +1,1 @@
+liquibase.ext.singlestore.SingleStoreConnection


### PR DESCRIPTION
Added connection attributes, we now append them directly to the JDBC connection URL during connection creation.
The connection is initialized using a modified URL that includes the required connection attributes. This ensures the attributes are consistently propagated to the database during handshake and are available for server-side inspection and logging.