### PR TITLE
[DAT-22479] Implement target uniqueness for SingleStoreDB — normalizeURL and product name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <liquibase.version>4.23.1</liquibase.version>
+        <liquibase.version>5.2.0</liquibase.version>
         <liquibase.sdk.github.token>${env.GITHUB_TOKEN}</liquibase.sdk.github.token>
         <spock.version>2.4-groovy-3.0</spock.version>
         <groovy.version>3.0.25</groovy.version>
@@ -66,6 +66,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.12.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.spockframework</groupId>
                 <artifactId>spock-bom</artifactId>
                 <version>2.4-groovy-3.0</version>
@@ -80,12 +87,6 @@
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
             <version>${liquibase.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-            <version>4.13.2</version>
         </dependency>
         <dependency>
             <groupId>org.liquibase</groupId>
@@ -128,6 +129,12 @@
             <groupId>org.skyscreamer</groupId>
             <artifactId>jsonassert</artifactId>
             <version>1.5.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>1.17.5</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/liquibase/ext/singlestore/SingleStoreDatabase.java
+++ b/src/main/java/liquibase/ext/singlestore/SingleStoreDatabase.java
@@ -4,6 +4,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
+
 import liquibase.database.DatabaseConnection;
 import liquibase.database.core.MariaDBDatabase;
 import liquibase.database.jvm.JdbcConnection;
@@ -66,5 +67,29 @@ public class SingleStoreDatabase extends MariaDBDatabase {
     @Override
     public boolean supportsSequences() {
       return false;
+    }
+
+    /**
+     * SingleStore can be reached via {@code jdbc:singlestore:}, {@code jdbc:mysql:}, or {@code jdbc:mariadb:} URLs.
+     * Normalize to {@code jdbc:singlestore:} so all produce the same target ID.
+     */
+    @Override
+    protected String resolveUrl(JdbcConnection jdbcConn) {
+        String url = super.resolveUrl(jdbcConn);
+        if (url != null) {
+            url = url.replace("jdbc:mariadb:", "jdbc:singlestore:");
+            url = url.replace("jdbc:mysql:", "jdbc:singlestore:");
+        }
+        return url;
+    }
+
+    /**
+     * When connected via MySQL or MariaDB drivers, {@code getDatabaseProductName()} may return
+     * "MySQL" or "MariaDB" instead of "SingleStore". Always return "SingleStore" for consistent
+     * target identification.
+     */
+    @Override
+    protected String resolveDatabaseProductName() {
+        return PRODUCT_NAME;
     }
 }

--- a/src/test/groovy/liquibase/ext/singlestore/SingleStoreDatabaseTest.groovy
+++ b/src/test/groovy/liquibase/ext/singlestore/SingleStoreDatabaseTest.groovy
@@ -1,0 +1,85 @@
+package liquibase.ext.singlestore
+
+import liquibase.database.jvm.JdbcConnection
+import spock.lang.Specification
+
+import java.sql.Connection
+import java.sql.DatabaseMetaData
+
+class SingleStoreDatabaseTest extends Specification {
+
+    // ---- Target Uniqueness ----
+
+    def "getTargetUniquenessAttributes schema is null and catalog is populated"() {
+        given:
+        def db = new SingleStoreDatabase()
+        db.setConnection(mockSingleStoreConnection("jdbc:singlestore://host:3306/mydb", "mydb", "SingleStore"))
+
+        when:
+        def attrs = db.getTargetUniquenessAttributes()
+
+        then:
+        attrs != null
+        attrs.schema == null
+        attrs.catalog == "mydb"
+    }
+
+    def "resolveUrl and resolveDatabaseProductName normalize all drivers to singlestore"() {
+        given:
+        def db1 = new SingleStoreDatabase()
+        db1.setConnection(mockSingleStoreConnection("jdbc:singlestore://host:3306/mydb", "mydb", "SingleStore"))
+        def db2 = new SingleStoreDatabase()
+        db2.setConnection(mockSingleStoreConnection("jdbc:mysql://host:3306/mydb", "mydb", "MySQL"))
+        def db3 = new SingleStoreDatabase()
+        db3.setConnection(mockSingleStoreConnection("jdbc:mariadb://host:3306/mydb", "mydb", "MariaDB"))
+
+        when:
+        def attrs1 = db1.getTargetUniquenessAttributes()
+        def attrs2 = db2.getTargetUniquenessAttributes()
+        def attrs3 = db3.getTargetUniquenessAttributes()
+
+        then:
+        attrs1.sanitizedUrl == "jdbc:singlestore://host:3306/mydb"
+        attrs2.sanitizedUrl == "jdbc:singlestore://host:3306/mydb"
+        attrs3.sanitizedUrl == "jdbc:singlestore://host:3306/mydb"
+        attrs1.databaseName == "SingleStore"
+        attrs2.databaseName == "SingleStore"
+        attrs3.databaseName == "SingleStore"
+        attrs1.targetId == attrs2.targetId
+        attrs1.targetId == attrs3.targetId
+    }
+
+    def "getTargetUniquenessAttributes different databases produce different target IDs"() {
+        given:
+        def db1 = new SingleStoreDatabase()
+        db1.setConnection(mockSingleStoreConnection("jdbc:singlestore://host:3306/orders", "orders", "SingleStore"))
+        def db2 = new SingleStoreDatabase()
+        db2.setConnection(mockSingleStoreConnection("jdbc:singlestore://host:3306/inventory", "inventory", "SingleStore"))
+
+        when:
+        def attrs1 = db1.getTargetUniquenessAttributes()
+        def attrs2 = db2.getTargetUniquenessAttributes()
+
+        then:
+        attrs1.targetId != attrs2.targetId
+    }
+
+    private JdbcConnection mockSingleStoreConnection(String url, String catalog, String productName) {
+        def conn = Mock(JdbcConnection)
+        def underlying = Mock(Connection)
+        def metadata = Mock(DatabaseMetaData)
+
+        conn.getURL() >> url
+        conn.getCatalog() >> catalog
+        conn.getConnectionUserName() >> "testuser"
+        conn.getAutoCommit() >> false
+        conn.getUnderlyingConnection() >> underlying
+        conn.getDatabaseProductName() >> productName
+        conn.isClosed() >> false
+        underlying.getSchema() >> null
+        underlying.getMetaData() >> metadata
+        metadata.supportsMixedCaseIdentifiers() >> false
+
+        return conn
+    }
+}


### PR DESCRIPTION
SingleStoreDatabase extends MariaDBDatabase and inherits resolveUrl() and resolveDatabaseProductName() overrides that would incorrectly normalize to MariaDB values. Override both to return SingleStore-specific values.

SingleStore can be reached via jdbc:singlestore://, jdbc:mysql://, or jdbc:mariadb:// drivers. All now produce the same target ID.

Changes:
- Override resolveUrl() in SingleStoreDatabase to normalize all URL prefixes to jdbc:singlestore:
- Override resolveDatabaseProductName() to always return "SingleStore"
- Add unit tests in SingleStoreDatabaseTest.groovy
- Update liquibase.version to 5.2.0, add junit-bom and byte-buddy test dependencies
- Remove unused JUnit 4 dependency