### PR TITLE
[DAT-22728] Fix: Update to canonical SHAs

### DIFF
--- a/.github/workflows/lth.yml
+++ b/.github/workflows/lth.yml
@@ -46,7 +46,7 @@ jobs:
         run: mvn -ntp -DdbVersion=${{ matrix.database-version }} -Dtest=liquibase.ext.singlestore.${{ matrix.liquibase-support-level }}ExtensionHarnessSuite test # Run the Liquibase test harness at each test level
 
       - name: Test Reporter # Generate a test report using the Test Reporter action
-        uses: dorny/test-reporter@b082adf0eced0765477756c2a610396589b8c637 # v2.5.0
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: always() # Run the action even if the previous steps fail
         with:
           name: Liquibase Test Harness - ${{ matrix.liquibase-support-level }} Reports # Set the name of the test report


### PR DESCRIPTION
## Summary
- Fix SHAs from previous PR which pinned to old tag versions instead of canonical SHAs from reference file

## Test plan
- [ ] Verify workflows run successfully with updated SHAs

🤖 Generated with [Claude Code](https://claude.com/claude-code)